### PR TITLE
Allow namespaced keywords as keys

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
            cljs-ajax/cljs-ajax       {:mvn/version "0.8.4"}
            re-frame/re-frame         {:mvn/version "1.4.3"}
            reagent/reagent           {:mvn/version "1.2.0"}
-           metosin/reitit-frontend   {:mvn/version "0.7.0-alpha7"}}
+           metosin/reitit-frontend   {:mvn/version "0.7.2"}}
  :paths   ["src" "resources" "modules/src" "template"],
  :aliases {:jar      {:extra-paths ["resources"]
                       :extra-deps  {luchiniatwork/cambada {:mvn/version "1.0.5"}},
@@ -13,15 +13,15 @@
                                     "-m" "--copy-source "]},
            :shadow-cljs  {:main-opts ["-m" "shadow.cljs.devtools.cli"]
                           :extra-deps
-                          {thheller/shadow-cljs {:mvn/version "2.28.3"}}}
+                          {thheller/shadow-cljs {:mvn/version "2.28.18"}}}
            :dev      {:extra-paths ["test/clj" "test/cljs"]
                       :extra-deps  {org.clojure/test.check {:mvn/version "1.1.1"}}}
            :test     {:extra-paths ["test/clj" "test/cljs"],
                       :extra-deps  {org.clojure/test.check {:mvn/version "1.1.1"}}},
            :unit     {:extra-paths ["test/clj" "test/cljs"]
-                      :extra-deps  {lambdaisland/kaocha {:mvn/version "1.88.1376"}},
+                      :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}},
                       :main-opts   ["-m" "kaocha.runner", "unit"]}
-           :it       {:extra-deps {lambdaisland/kaocha {:mvn/version "1.88.1376"}},
+           :it       {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}},
                       :main-opts  ["-m" "kaocha.runner", "it"]}
            :readme   {:extra-paths ["target/src"]
                       :extra-deps  {alpha-prosoft/readme {:mvn/version "1.7"}}

--- a/src/edd/client.cljs
+++ b/src/edd/client.cljs
@@ -237,6 +237,11 @@
                                         "?dbg_service=" service
                                         "&dbg_cmds=" (string/join "," (map :cmd-id commands))))))
 
+(defn convert-keyword->js [key-word]
+  (if-let [keyword-namespace (namespace key-word)]
+    (str keyword-namespace "/" (name key-word))
+    (name key-word)))
+
 (defn get-body-str [{:keys [query commands]} mock-for]
   (let [ref (case mock-for
               :query {:request-id     (str "#" (random-uuid))
@@ -245,7 +250,8 @@
               :commands {:request-id     (str "#" (random-uuid))
                          :interaction-id utils/interaction-id
                          :commands       commands})]
-    (clj->js (json/encode-custom-fields (add-user ref)))))
+    (clj->js (json/encode-custom-fields (add-user ref))
+             {:keyword-fn convert-keyword->js})))
 
 (defn do-post-with-retry
   ([post-for props retry-attempts]

--- a/src/edd/i18n.cljs
+++ b/src/edd/i18n.cljs
@@ -21,15 +21,15 @@
               (concat [lang]
                       prop))
         val (get-in @(rf/subscribe [::subs/translations])
-            prop
-            (str "{tr " prop "}"))]
+                    prop
+                    (str "{tr " prop "}"))]
     (when-not (string? val)
       (throw (js/Error. (str
-                        "Translation key does not result in string: "
-                        (->> {:key prop
-                             :value val}
-                            clj->js
-                            (.stringify js/JSON))))))
+                         "Translation key does not result in string: "
+                         (->> {:key prop
+                               :value val}
+                              clj->js
+                              (.stringify js/JSON))))))
     val))
 
 (comment

--- a/src/edd/json.cljc
+++ b/src/edd/json.cljc
@@ -48,7 +48,7 @@
 (defn convert
   [x]
   (cond
-    (keyword? x) (str ":" (name x))
+    (keyword? x) (str x)
     (uuid? x) (str "#" x)
     (coll? x) (fmap convert x)
     :else x))

--- a/test/clj/edd/json_parser_test.clj
+++ b/test/clj/edd/json_parser_test.clj
@@ -56,5 +56,18 @@
                                        (str "#"
                                             id)) ":a"
                                       :b  1})))))
+
+(deftest test-convert
+  "Test converting edn keys"
+
+  (are [expected input] (= expected (json/convert input))
+    ":x" :x
+    ":>aggregate/references" :>aggregate/references
+    "#4fb62f2c-9c1d-4043-9c74-bbe2e017befc" #uuid "4fb62f2c-9c1d-4043-9c74-bbe2e017befc"
+    "key" "key"
+    [":a" 1] [:a 1]
+    [{:a "#4fb62f2c-9c1d-4043-9c74-bbe2e017befc"}] [{:a #uuid "4fb62f2c-9c1d-4043-9c74-bbe2e017befc"}]
+    1 1))
+
 (run-tests 'edd.json-parser-test)
 


### PR DESCRIPTION
Allow namespaced keyword .e.g `aggregate/references` as JSON key in payload instead of stripping to 'name' e.g. `references`.